### PR TITLE
Bring up to date with Python 3.10

### DIFF
--- a/geothermsim/basis.py
+++ b/geothermsim/basis.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from collections.abc import Callable
-from typing import Self, Tuple
+from typing import Tuple
+from typing_extensions import Self
 
 from jax import numpy as jnp
 from jax import Array, jit, vmap

--- a/geothermsim/borefield/borefield.py
+++ b/geothermsim/borefield/borefield.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from typing import List, Self
+from typing import List
+from typing_extensions import Self
 
 from jax import numpy as jnp
 from jax import Array, jit, vmap

--- a/geothermsim/borefield/network.py
+++ b/geothermsim/borefield/network.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 from collections.abc import Callable
 from functools import partial
-from typing import List, Self, Tuple
+from typing import List, Tuple
+from typing_extensions import Self
 
 from jax import numpy as jnp
 from jax import Array, jit, vmap

--- a/geothermsim/borehole/_tube.py
+++ b/geothermsim/borehole/_tube.py
@@ -2,7 +2,8 @@
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from functools import partial
-from typing import Self, Tuple
+from typing import Tuple
+from typing_extensions import Self
 
 from jax import numpy as jnp
 from jax import Array, jit, vmap

--- a/geothermsim/borehole/borehole.py
+++ b/geothermsim/borehole/borehole.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from functools import partial
-from typing import Self, Tuple
+from typing import Tuple
+from typing_extensions import Self
 
 from jax import numpy as jnp
 from jax import Array, jit, vmap

--- a/geothermsim/ground_heat_exchanger/coaxial_heat_exchanger.py
+++ b/geothermsim/ground_heat_exchanger/coaxial_heat_exchanger.py
@@ -172,7 +172,7 @@ class CoaxialHeatExchanger(_GroundHeatExchanger):
         R_d_grout = self.multipole.thermal_resistances(R_fp)
         # Full delta-circuit of thermal resistances
         R_d = jnp.full((self.n_pipes, self.n_pipes), jnp.inf)
-        R_d = R_d.at[*self._indices_outer_mesh].set(R_d_grout)
+        R_d = R_d.at[self._indices_outer_mesh].set(R_d_grout)
         R_d = R_d.at[self.indices_outer, self.indices_inner].set(R_ff)
         R_d = R_d.at[self.indices_inner, self.indices_outer].set(R_ff)
         return R_d

--- a/geothermsim/path.py
+++ b/geothermsim/path.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from collections.abc import Callable
 from functools import partial
-from typing import Self
+from typing_extensions import Self
 
 from interpax import Interpolator1D
 from jax import numpy as jnp

--- a/geothermsim/utilities/quad.py
+++ b/geothermsim/utilities/quad.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from collections.abc import Callable
-from typing import Self, Tuple
+from typing import Tuple
+from typing_extensions import Self
 
 from jax import numpy as jnp
 from jax import Array, jit, vmap

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ matplotlib >= 3.10.0
 pandas >= 2.2.3
 SecondaryCoolantProps >= 1.3.0
 scipy >= 1.15.1
+typing_extensions >= 4.14.0


### PR DESCRIPTION
Hi @MassimoCimmino ,

As suggested, it would be great to make this repo compatible with Python 3.10. I made a few changes:

- In Python 3.10, Self is not in the typings packages, but typings_extensions. This is changed in a couple of files.
- Using the * notation is not available in Python 3.10 like in for example the multipole class
```Python
 A = self.A.at[*diag_indices].add(jnp.concatenate([coeffs.flatten(), -coeffs.flatten()]))
```
I tried updating this to a syntax that is compatible with Python 3.10.
Since there are no unit-tests and I'm not that familiar with JAX, perhaps you can take a look at the replacements of the * notation.

Best,
Wouter